### PR TITLE
Update client.lua

### DIFF
--- a/[Money]/Money_Script/source/client.lua
+++ b/[Money]/Money_Script/source/client.lua
@@ -93,6 +93,26 @@ AddEventHandler("receiveBank", function(amount, playerSending, playerId)
     TriggerServerEvent("updateMoney")
 end)
 
+--Added by Resq to allow the correct icon (+) to show when money is added when someone uses the export and TriggerClientEvent in another script. Need to use TriggerClientEvent("updateAddMoney", player, amount, "cash") or "bank" depnding on the useage
+RegisterNetEvent("updateAddMoney")
+AddEventHandler("updateAddMoney", function(amount, type)
+    if type == "cash" then
+        amount = "~r~+ ~g~$~w~".. amount
+    elseif type == "bank" then
+        amount = "~r~+ ~b~$~w~".. amount
+    else
+        amount = amount
+    end
+
+    local time = 0
+    while time < 300 do
+        Citizen.Wait(0)
+        text(amount, 0.8971, 0.11, 0.55)
+        time = time + 1
+    end
+    TriggerServerEvent("updateAddMoney")
+end)
+
 -- Notification when you receive cash.
 RegisterNetEvent("receiveCash")
 AddEventHandler("receiveCash", function(amount, playerSending, playerId)


### PR DESCRIPTION
Added Client Event for updateAddMoney to allow the + icon to be displayed when someone uses the export and TriggerClientEvent from a script in which the player would receive money. Currently the only option was to use TriggerClientEvent("updateMoney" xxxx) which only allows for a - symbol even when money is being added. Now they can use TriggerClientEvent("updateAddMoney" xxxx) when the player should receive money so it will show the + symbol. (edit to server.lua to follow immediately after this)